### PR TITLE
refactor: melhorar flexibilidade e correção de mensagens

### DIFF
--- a/src/Masstransit.Publisher.Domain/Classes/CustomPropertyMockSettings.cs
+++ b/src/Masstransit.Publisher.Domain/Classes/CustomPropertyMockSettings.cs
@@ -3,7 +3,7 @@
     public class CustomPropertyMockSettings
     {
         public string Name { get; set; } = string.Empty;
-        public string? Value { get; set; }
+        public object? Value { get; set; }
         public string? Type { get; set; }
         public bool Ignore { get; set; }
         public bool RegenerateBeforeSending { get; set; }

--- a/src/Masstransit.Publisher.Windows/Forms/UserControls/UserControlMockSettings.cs
+++ b/src/Masstransit.Publisher.Windows/Forms/UserControls/UserControlMockSettings.cs
@@ -31,7 +31,7 @@ namespace Masstransit.Publisher.Windows.Forms.UserControls
 
             textBoxName.Text = propertySettings.Name;
             comboBoxType.SelectedItem = propertySettings.Type;
-            textBoxValue.Text = propertySettings.Value;
+            textBoxValue.Text = propertySettings.Value?.ToString();
             checkBoxIgnore.Checked = propertySettings.Ignore;
             checkBoxRegenerateBeforeSending.Checked = propertySettings.RegenerateBeforeSending;
         }


### PR DESCRIPTION
Aumentada a flexibilidade ao permitir valores de tipos variados em configurações personalizadas. Removida a necessidade de resolução de tipo de mensagem original, simplificando o fluxo. Corrigida a verificação de propriedades de mensagem de sucesso, garantindo que a propriedade correta seja utilizada. Ajustado o foco de mensagens de falha para mensagens de assinatura, promovendo uma abordagem mais genérica. Melhorada a conversão de valores para texto, assegurando compatibilidade com valores nulos.